### PR TITLE
feat: NX-15726 return a typed APIError with status code and body

### DIFF
--- a/epostbusiness_test.go
+++ b/epostbusiness_test.go
@@ -8,7 +8,12 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
+
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, errors.New("read failed") }
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
@@ -65,8 +70,9 @@ func TestNewAPIErrorParsesEnvelope(t *testing.T) {
 	if e.Description != "Fehler in Sendungsverarbeitung" {
 		t.Errorf("Description = %q", e.Description)
 	}
-	if e.Date.IsZero() {
-		t.Error("Date was not parsed")
+	wantDate, _ := time.Parse(time.RFC3339, "2026-06-11T08:45:58Z")
+	if !e.Date.Equal(wantDate) {
+		t.Errorf("Date = %v, want %v", e.Date, wantDate)
 	}
 	if string(e.Body) != body {
 		t.Errorf("Body = %q, want the raw body", e.Body)
@@ -100,6 +106,18 @@ func TestNewAPIErrorNilResponse(t *testing.T) {
 	}
 	if len(e.Body) != 0 {
 		t.Errorf("Body = %q, want empty for a nil response body", e.Body)
+	}
+}
+
+func TestNewAPIErrorReadError(t *testing.T) {
+	// A body read failure must not crash; status is still captured, body is empty.
+	e := newAPIError(&http.Response{StatusCode: http.StatusBadGateway, Body: io.NopCloser(errReader{})})
+
+	if e.StatusCode != http.StatusBadGateway {
+		t.Errorf("StatusCode = %d, want 502", e.StatusCode)
+	}
+	if len(e.Body) != 0 {
+		t.Errorf("Body = %q, want empty on read error", e.Body)
 	}
 }
 

--- a/epostbusiness_test.go
+++ b/epostbusiness_test.go
@@ -1,0 +1,164 @@
+package epostbusiness
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// newTestAPI returns an API whose HTTP client answers every request with the given
+// status and body, so the error paths can be exercised without network access.
+func newTestAPI(status int, body string) *API {
+	api := New()
+	api.Client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: status,
+			Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)),
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+	return api
+}
+
+func TestAPIErrorError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  APIError
+		want string
+	}{
+		{"with code and description", APIError{Code: "E315", Description: "Fehler in Sendungsverarbeitung"}, "E315: Fehler in Sendungsverarbeitung"},
+		{"empty envelope falls back to status", APIError{StatusCode: http.StatusBadGateway}, "epostbusiness: unexpected status 502"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.err.Error(); got != c.want {
+				t.Fatalf("Error() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestNewAPIErrorParsesEnvelope(t *testing.T) {
+	const body = `{"level":"Error","code":"E315","description":"Fehler in Sendungsverarbeitung","date":"2026-06-11T08:45:58Z"}`
+	e := newAPIError(&http.Response{StatusCode: http.StatusBadRequest, Body: io.NopCloser(strings.NewReader(body))})
+
+	if e.StatusCode != http.StatusBadRequest {
+		t.Errorf("StatusCode = %d, want 400", e.StatusCode)
+	}
+	if e.Code != "E315" {
+		t.Errorf("Code = %q, want E315", e.Code)
+	}
+	if e.Level != "Error" {
+		t.Errorf("Level = %q, want Error", e.Level)
+	}
+	if e.Description != "Fehler in Sendungsverarbeitung" {
+		t.Errorf("Description = %q", e.Description)
+	}
+	if e.Date.IsZero() {
+		t.Error("Date was not parsed")
+	}
+	if string(e.Body) != body {
+		t.Errorf("Body = %q, want the raw body", e.Body)
+	}
+}
+
+func TestNewAPIErrorNonJSONBody(t *testing.T) {
+	const body = "<html>502 Bad Gateway</html>"
+	e := newAPIError(&http.Response{StatusCode: http.StatusBadGateway, Body: io.NopCloser(strings.NewReader(body))})
+
+	if e.StatusCode != http.StatusBadGateway {
+		t.Errorf("StatusCode = %d, want 502", e.StatusCode)
+	}
+	if e.Code != "" || e.Description != "" {
+		t.Errorf("expected empty envelope fields, got code=%q description=%q", e.Code, e.Description)
+	}
+	if string(e.Body) != body {
+		t.Errorf("Body = %q, want the raw body", e.Body)
+	}
+}
+
+func TestNewAPIErrorBoundsBody(t *testing.T) {
+	big := strings.Repeat("a", maxErrorBodyBytes+1024)
+	e := newAPIError(&http.Response{StatusCode: http.StatusInternalServerError, Body: io.NopCloser(strings.NewReader(big))})
+
+	if len(e.Body) != maxErrorBodyBytes {
+		t.Errorf("Body length = %d, want %d (bounded)", len(e.Body), maxErrorBodyBytes)
+	}
+}
+
+func TestLoginReturnsAPIError(t *testing.T) {
+	const body = `{"level":"Error","code":"E001","description":"invalid credentials"}`
+	api := newTestAPI(http.StatusUnauthorized, body)
+
+	ok, err := api.Login(context.Background(), "vendor", "ekp", "secret", "password")
+	if ok {
+		t.Error("ok = true, want false")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error is not *APIError: %v", err)
+	}
+	if apiErr.StatusCode != http.StatusUnauthorized {
+		t.Errorf("StatusCode = %d, want 401", apiErr.StatusCode)
+	}
+	if apiErr.Code != "E001" {
+		t.Errorf("Code = %q, want E001", apiErr.Code)
+	}
+	if string(apiErr.Body) != body {
+		t.Error("raw Body was not preserved")
+	}
+}
+
+func TestLoginSuccess(t *testing.T) {
+	api := newTestAPI(http.StatusOK, `{"token":"jwt-123"}`)
+
+	ok, err := api.Login(context.Background(), "vendor", "ekp", "secret", "password")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Error("ok = false, want true")
+	}
+	if api.jwt != "jwt-123" {
+		t.Errorf("jwt = %q, want jwt-123", api.jwt)
+	}
+}
+
+func TestCreateLettersReturnsAPIError(t *testing.T) {
+	const body = `{"level":"Error","code":"E315","description":"Fehler in Sendungsverarbeitung"}`
+	api := newTestAPI(http.StatusBadRequest, body)
+
+	_, err := api.CreateLetters(context.Background(), []Letter{{}})
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error is not *APIError: %v", err)
+	}
+	if apiErr.StatusCode != http.StatusBadRequest {
+		t.Errorf("StatusCode = %d, want 400", apiErr.StatusCode)
+	}
+	if apiErr.Code != "E315" {
+		t.Errorf("Code = %q, want E315", apiErr.Code)
+	}
+}
+
+func TestGetLettersStatusListReturnsAPIError(t *testing.T) {
+	api := newTestAPI(http.StatusTooManyRequests, `{"code":"E429","description":"rate limited"}`)
+
+	_, err := api.GetLettersStatusList(context.Background(), []int{1})
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error is not *APIError: %v", err)
+	}
+	if apiErr.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("StatusCode = %d, want 429", apiErr.StatusCode)
+	}
+}

--- a/epostbusiness_test.go
+++ b/epostbusiness_test.go
@@ -32,11 +32,13 @@ func newTestAPI(status int, body string) *API {
 func TestAPIErrorError(t *testing.T) {
 	cases := []struct {
 		name string
-		err  APIError
+		err  *APIError
 		want string
 	}{
-		{"with code and description", APIError{Code: "E315", Description: "Fehler in Sendungsverarbeitung"}, "E315: Fehler in Sendungsverarbeitung"},
-		{"empty envelope falls back to status", APIError{StatusCode: http.StatusBadGateway}, "epostbusiness: unexpected status 502"},
+		{"with code and description", &APIError{Code: "E315", Description: "Fehler in Sendungsverarbeitung"}, "E315: Fehler in Sendungsverarbeitung"},
+		{"description only", &APIError{Description: "Fehler in Sendungsverarbeitung"}, "Fehler in Sendungsverarbeitung"},
+		{"code only", &APIError{Code: "E315"}, "error code E315"},
+		{"empty envelope falls back to status", &APIError{StatusCode: http.StatusBadGateway}, "epostbusiness: unexpected status 502"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -68,6 +70,36 @@ func TestNewAPIErrorParsesEnvelope(t *testing.T) {
 	}
 	if string(e.Body) != body {
 		t.Errorf("Body = %q, want the raw body", e.Body)
+	}
+}
+
+func TestNewAPIErrorMalformedDate(t *testing.T) {
+	// A missing or non-RFC3339 date must not drop the rest of the envelope.
+	const body = `{"level":"Error","code":"E315","description":"Fehler","date":"not-a-date"}`
+	e := newAPIError(&http.Response{StatusCode: http.StatusBadRequest, Body: io.NopCloser(strings.NewReader(body))})
+
+	if e.Code != "E315" {
+		t.Errorf("Code = %q, want E315 (must survive a bad date)", e.Code)
+	}
+	if e.Description != "Fehler" {
+		t.Errorf("Description = %q, want Fehler", e.Description)
+	}
+	if !e.Date.IsZero() {
+		t.Errorf("Date = %v, want zero for an unparseable date", e.Date)
+	}
+}
+
+func TestNewAPIErrorNilResponse(t *testing.T) {
+	if e := newAPIError(nil); e == nil {
+		t.Fatal("newAPIError(nil) returned nil, want non-nil *APIError")
+	}
+
+	e := newAPIError(&http.Response{StatusCode: http.StatusBadGateway})
+	if e.StatusCode != http.StatusBadGateway {
+		t.Errorf("StatusCode = %d, want 502", e.StatusCode)
+	}
+	if len(e.Body) != 0 {
+		t.Errorf("Body = %q, want empty for a nil response body", e.Body)
 	}
 }
 

--- a/error.go
+++ b/error.go
@@ -1,0 +1,58 @@
+package epostbusiness
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// maxErrorBodyBytes bounds how much of a non-2xx response body is read into an
+// APIError, guarding against an unexpectedly large body.
+const maxErrorBodyBytes = 1 << 20 // 1 MiB
+
+// APIError is returned when the E-POSTBUSINESS API responds with a non-2xx status.
+// It preserves the HTTP status code and the raw response body so callers can log
+// and react to the actual provider error instead of a flattened message. When the
+// body is the provider's JSON error envelope, its fields are parsed out too.
+type APIError struct {
+	StatusCode  int       // HTTP status code returned by the API.
+	Code        string    // Provider error code (e.g. "E315"), if the body parsed.
+	Level       string    // Provider error level, if the body parsed.
+	Description string    // Provider error description, if the body parsed.
+	Date        time.Time // Provider error timestamp, if the body parsed.
+	Body        []byte    // Raw response body (bounded by maxErrorBodyBytes).
+}
+
+func (e *APIError) Error() string {
+	if e.Code != "" || e.Description != "" {
+		return fmt.Sprintf("%s: %s", e.Code, e.Description)
+	}
+	return fmt.Sprintf("epostbusiness: unexpected status %d", e.StatusCode)
+}
+
+type errorEnvelope struct {
+	Level       string    `json:"level"`
+	Code        string    `json:"code"`
+	Description string    `json:"description"`
+	Date        time.Time `json:"date"`
+}
+
+// newAPIError reads the (bounded) response body and builds an APIError, parsing the
+// provider's JSON error envelope when present. The caller still closes res.Body.
+func newAPIError(res *http.Response) *APIError {
+	body, _ := io.ReadAll(io.LimitReader(res.Body, maxErrorBodyBytes))
+
+	e := &APIError{StatusCode: res.StatusCode, Body: body}
+
+	var env errorEnvelope
+	if json.Unmarshal(body, &env) == nil {
+		e.Code = env.Code
+		e.Level = env.Level
+		e.Description = env.Description
+		e.Date = env.Date
+	}
+
+	return e
+}

--- a/error.go
+++ b/error.go
@@ -13,9 +13,9 @@ import (
 const maxErrorBodyBytes = 1 << 20 // 1 MiB
 
 // APIError is returned when the E-POSTBUSINESS API responds with a non-2xx status.
-// It preserves the HTTP status code and the raw response body so callers can log
-// and react to the actual provider error instead of a flattened message. When the
-// body is the provider's JSON error envelope, its fields are parsed out too.
+// It preserves the HTTP status code and the raw response body so callers can log and
+// react to the actual provider error. When the body is the provider's JSON error
+// envelope, its fields are parsed out too.
 type APIError struct {
 	StatusCode  int       // HTTP status code returned by the API.
 	Code        string    // Provider error code (e.g. "E315"), if the body parsed.

--- a/error.go
+++ b/error.go
@@ -26,23 +26,40 @@ type APIError struct {
 }
 
 func (e *APIError) Error() string {
-	if e.Code != "" || e.Description != "" {
+	switch {
+	case e.Code != "" && e.Description != "":
 		return fmt.Sprintf("%s: %s", e.Code, e.Description)
+	case e.Description != "":
+		return e.Description
+	case e.Code != "":
+		return fmt.Sprintf("error code %s", e.Code)
+	default:
+		return fmt.Sprintf("epostbusiness: unexpected status %d", e.StatusCode)
 	}
-	return fmt.Sprintf("epostbusiness: unexpected status %d", e.StatusCode)
 }
 
+// errorEnvelope is the provider's JSON error body. Date is a string (parsed
+// separately) so a missing or non-RFC3339 date does not fail the whole decode and
+// drop the code/level/description.
 type errorEnvelope struct {
-	Level       string    `json:"level"`
-	Code        string    `json:"code"`
-	Description string    `json:"description"`
-	Date        time.Time `json:"date"`
+	Level       string `json:"level"`
+	Code        string `json:"code"`
+	Description string `json:"description"`
+	Date        string `json:"date"`
 }
 
 // newAPIError reads the (bounded) response body and builds an APIError, parsing the
-// provider's JSON error envelope when present. The caller still closes res.Body.
+// provider's JSON error envelope when present. It always returns a non-nil
+// *APIError. The caller still closes res.Body.
 func newAPIError(res *http.Response) *APIError {
-	body, _ := io.ReadAll(io.LimitReader(res.Body, maxErrorBodyBytes))
+	if res == nil {
+		return &APIError{}
+	}
+
+	var body []byte
+	if res.Body != nil {
+		body, _ = io.ReadAll(io.LimitReader(res.Body, maxErrorBodyBytes))
+	}
 
 	e := &APIError{StatusCode: res.StatusCode, Body: body}
 
@@ -51,7 +68,11 @@ func newAPIError(res *http.Response) *APIError {
 		e.Code = env.Code
 		e.Level = env.Level
 		e.Description = env.Description
-		e.Date = env.Date
+		if env.Date != "" {
+			if date, perr := time.Parse(time.RFC3339, env.Date); perr == nil {
+				e.Date = date
+			}
+		}
 	}
 
 	return e

--- a/error.go
+++ b/error.go
@@ -26,6 +26,9 @@ type APIError struct {
 }
 
 func (e *APIError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
 	switch {
 	case e.Code != "" && e.Description != "":
 		return fmt.Sprintf("%s: %s", e.Code, e.Description)
@@ -64,7 +67,7 @@ func newAPIError(res *http.Response) *APIError {
 	e := &APIError{StatusCode: res.StatusCode, Body: body}
 
 	var env errorEnvelope
-	if json.Unmarshal(body, &env) == nil {
+	if len(body) > 0 && json.Unmarshal(body, &env) == nil {
 		e.Code = env.Code
 		e.Level = env.Level
 		e.Description = env.Description

--- a/letter.go
+++ b/letter.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
-	"fmt"
 	"net/http"
 )
 
@@ -63,32 +61,15 @@ func (a API) CreateLetters(ctx context.Context, letters []Letter) ([]LetterIdent
 		}
 	}()
 
-	switch res.StatusCode {
-	case http.StatusOK:
-		err = json.NewDecoder(res.Body).Decode(&letterIdentifiers)
-		if err != nil {
-			return nil, err
-		}
-
-		return letterIdentifiers, nil
-
-	case http.StatusBadRequest:
-		fallthrough
-	case http.StatusUnauthorized:
-		fallthrough
-	case http.StatusTooManyRequests:
-		var loginErr loginError
-
-		err = json.NewDecoder(res.Body).Decode(&loginErr)
-		if err != nil {
-			return nil, err
-		}
-
-		return nil, fmt.Errorf("%s: %s", loginErr.Code, loginErr.Description)
-
-	default:
-		return nil, errors.New(res.Status)
+	if res.StatusCode != http.StatusOK {
+		return nil, newAPIError(res)
 	}
+
+	if err = json.NewDecoder(res.Body).Decode(&letterIdentifiers); err != nil {
+		return nil, err
+	}
+
+	return letterIdentifiers, nil
 }
 
 type LetterStatus struct {
@@ -158,11 +139,10 @@ func (a API) GetLettersStatusList(ctx context.Context, letterIDs []int) ([]Lette
 	}()
 
 	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%d: %s", res.StatusCode, res.Status)
+		return nil, newAPIError(res)
 	}
 
-	err = json.NewDecoder(res.Body).Decode(&statusList)
-	if err != nil {
+	if err = json.NewDecoder(res.Body).Decode(&statusList); err != nil {
 		return nil, err
 	}
 

--- a/login.go
+++ b/login.go
@@ -4,10 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
-	"fmt"
 	"net/http"
-	"time"
 )
 
 type login struct {
@@ -19,13 +16,6 @@ type login struct {
 
 type loginToken struct {
 	Token string `json:"token"`
-}
-
-type loginError struct {
-	Level       string    `json:"level"`
-	Code        string    `json:"code"`
-	Description string    `json:"description"`
-	Date        time.Time `json:"date"`
 }
 
 func (a *API) Login(ctx context.Context, vendorID, ekp, secret, password string) (bool, error) {
@@ -56,31 +46,16 @@ func (a *API) Login(ctx context.Context, vendorID, ekp, secret, password string)
 		}
 	}()
 
-	switch res.StatusCode {
-	case http.StatusOK:
-		var token loginToken
-		err = json.NewDecoder(res.Body).Decode(&token)
-		if err != nil {
-			return false, err
-		}
-
-		a.jwt = token.Token
-		return true, nil
-
-	case http.StatusBadRequest:
-		fallthrough
-	case http.StatusUnauthorized:
-		fallthrough
-	case http.StatusTooManyRequests:
-		var loginErr loginError
-		err = json.NewDecoder(res.Body).Decode(&loginErr)
-		if err != nil {
-			return false, err
-		}
-
-		return false, fmt.Errorf("%s: %s", loginErr.Code, loginErr.Description)
-
-	default:
-		return false, errors.New(res.Status)
+	if res.StatusCode != http.StatusOK {
+		return false, newAPIError(res)
 	}
+
+	var token loginToken
+	if err = json.NewDecoder(res.Body).Decode(&token); err != nil {
+		return false, err
+	}
+
+	a.jwt = token.Token
+
+	return true, nil
 }


### PR DESCRIPTION
## What & Why
On a non-2xx response, `Login`, `CreateLetters` and `GetLettersStatusList` collapsed the provider response to `fmt.Errorf("%s: %s", code, description)` (or just the status text) and **discarded the HTTP status code and the rest of the body**. That made provider rejections undiagnosable downstream — e.g. a prod ePost send failed with `E315: Fehler in Sendungsverarbeitung...` and the consumer (negsoft-api) could not tell 400 vs 401 vs 429/5xx or see anything else the provider returned.

Jira: NX-15726

## Key Changes
- New typed `*APIError` (`error.go`) carrying `StatusCode`, `Code`, `Level`, `Description`, `Date` and the raw `Body` (bounded to 1 MiB). It parses the provider's JSON error envelope when present; the `Date` is parsed as a string separately so a missing/non-RFC3339 date does not drop the rest of the envelope.
- `Login`, `CreateLetters`, `GetLettersStatusList` now return `*APIError` for every non-2xx response.
- `Error()` renders `"code: description"` (so existing callers are unaffected), with graceful fallbacks and a nil-receiver guard.
- Tests (stdlib only — no new deps): envelope parsing, malformed/valid date, nil-response, read-error, body bound, and `errors.As` on all three methods.

## Backward compatibility
`APIError.Error()` still renders `"code: description"`. Callers that want the status/body use `errors.As(err, &apiErr)`. Suggest tagging as **v0.3.0**.

## Validated end-to-end
The consumer (negsoft-api, against this branch via pseudo-version) was deployed to stage and a real DocuGuide rejection (`E313`, city required) surfaced through `errors.As` with `epost_status=400` + code + description logged. `exception_type=*epostbusiness.APIError` confirms the typed error propagates through the wrap chain.

## Testing
- `gofmt -l .` — clean
- `go vet ./...` — clean
- `go test ./...` — 11 tests pass